### PR TITLE
更新示例代码的url为okex.com

### DIFF
--- a/python/Client.py
+++ b/python/Client.py
@@ -9,7 +9,7 @@ from OkcoinFutureAPI import OKCoinFuture
 #初始化apikey，secretkey,url
 apikey = 'XXXX'
 secretkey = 'XXXXX'
-okcoinRESTURL = 'www.okcoin.com'   #请求注意：国内账号需要 修改为 www.okcoin.cn  
+okcoinRESTURL = 'www.okex.com'   #请求注意：国内账号需要 修改为 www.okcoin.cn  
 
 #现货API
 okcoinSpot = OKCoinSpot(okcoinRESTURL,apikey,secretkey)


### PR DESCRIPTION
原来的www.okcoin.com对trades之后的会报错
 现货历史交易信息
HTTP GET: www.okcoin.com /api/v1/trades.do?symbol=ltc_btc
{'error_code': 1007}